### PR TITLE
Add Docker container for the cserver game server

### DIFF
--- a/server/cserver/BoardSpaceServer.docker.conf
+++ b/server/cserver/BoardSpaceServer.docker.conf
@@ -1,0 +1,163 @@
+#main log file
+logfile,/data/logs/Server.log
+chatfile,/data/logs/Chat.log
+securityfile,/data/logs/Security.log
+max_logfile_megabytes,10
+crash-test,0
+use-threads,1
+detatch,1
+#ip address to bind, needed if strict is enabled
+#
+# KNOWN LIMITATION: strict mode trusts connections whose source IP matches
+# either this value or the hardcoded 127.0.0.1 fallback in migs.c. That
+# assumption held when Apache and this server shared a host/loopback; it
+# does NOT hold once Apache/CGI runs in a separate container, since neither
+# value will match the real container-to-container IP on the Docker
+# network. Left at strict,0 below until the planned HMAC-based replacement
+# for this mechanism is in place. Re-enable strict,1 only after that work
+# lands, and set bindip to whatever the actual trust check will compare
+# against at that point.
+bindip,127.0.0.1
+# strict logins and checking of game results
+strict,0
+# 0 is no, 1 is normal, 2 is never score
+strict-score,1
+# game port
+port,2255
+# log level, 0=none 2=normal 3=everything
+loglevel,2
+# password for lobby commands
+password,BSxyzzy
+# realtime status monitor
+statusfile,/data/status/Server_Status.html
+player-info-url,/cgi-bin/edit.cgi?pname=%s
+#
+# first char is G or N for game type or non-game type
+#
+nroomtypes,10
+roomtype0,GGame
+roomtype1,NChat
+roomtype2,GReview
+roomtype3,NMap
+roomtype4,GUnranked
+roomtype5,GMaster
+roomtype6,
+roomtype7,
+roomtype8,
+roomtype9,
+
+
+# players and rooms
+players,220
+rooms,80,
+connections,100
+connections-per-session,12
+connections-per-uid,15
+gamecachedir,/data/games/
+gamecacherate,4
+client-timeout,120
+lobby-timeout,120
+
+
+
+#list produded by database_info.pl
+ngametypes,49
+gametype0,zertz
+gametype1,loa
+gametype2,plateau
+gametype3,yinsh
+gametype4,hex
+gametype5,looptrax
+gametype6,punct
+gametype7,gobblet
+gametype8,hive
+gametype9,exxit
+gametype10,tablut
+gametype11,truchet
+gametype12,tumblingdown
+gametype13,dipole
+gametype14,fanorona
+gametype15,volcano
+gametype16,kuba
+gametype17,dvonn
+gametype18,tzaar
+gametype19,qyshinsu
+gametype20,knockabout
+gametype21,gipf
+gametype22,palago
+gametype23,santorini
+gametype24,spangles
+gametype25,che
+gametype26,micropul
+gametype27,yavalath
+gametype28,mutton
+gametype29,medina
+gametype30,cannon
+gametype31,warp6
+gametype32,tajii
+gametype33,triad
+gametype34,octiles
+gametype35,frogs
+gametype36,breakingaway
+gametype37,xiangqi
+gametype38,container
+gametype39,arimaa
+gametype40,crossfire
+gametype41,entrapment
+gametype42,lehavre
+gametype43,gounki
+gametype44,quinamid
+gametype45,twixt
+gametype46,yspahan
+gametype47,volo
+gametype48,cookie-disco
+ngamedirs,49
+gamedir0,/data/www/zertz/games/
+gamedir1,/data/www/loa/loagames/
+gamedir2,/data/www/plateau/plateaugames/
+gamedir3,/data/www/yinsh/yinshgames/
+gamedir4,/data/www/hex/hexgames/
+gamedir5,/data/www/trax/traxgames/
+gamedir6,/data/www/punct/punctgames/
+gamedir7,/data/www/gobblet/gobbletgames/
+gamedir8,/data/www/hive/hivegames/
+gamedir9,/data/www/exxit/exxitgames/
+gamedir10,/data/www/tablut/tablutgames/
+gamedir11,/data/www/truchet/truchetgames/
+gamedir12,/data/www/tumble/tumblegames/
+gamedir13,/data/www/dipole/dipolegames/
+gamedir14,/data/www/fanorona/fanoronagames/
+gamedir15,/data/www/volcano/volcanogames/
+gamedir16,/data/www/kuba/kubagames/
+gamedir17,/data/www/dvonn/dvonngames/
+gamedir18,/data/www/tzaar/tzaargames/
+gamedir19,/data/www/qyshinsu/qyshinsugames/
+gamedir20,/data/www/knockabout/knockaboutgames/
+gamedir21,/data/www/gipf/gipfgames/
+gamedir22,/data/www/palago/palagogames/
+gamedir23,/data/www/santorini/santorinigames/
+gamedir24,/data/www/spangles/spanglesgames/
+gamedir25,/data/www/che/chegames/
+gamedir26,/data/www/micropul/micropulgames/
+gamedir27,/data/www/yavalath/yavalathgames/
+gamedir28,/data/www/mutton/muttongames/
+gamedir29,/data/www/medina/medinagames/
+gamedir30,/data/www/cannon/cannongames/
+gamedir31,/data/www/warp6/warp6games/
+gamedir32,/data/www/tajii/tajiigames/
+gamedir33,/data/www/triad/triadgames/
+gamedir34,/data/www/octiles/octilesgames/
+gamedir35,/data/www/frogs/frogsgames/
+gamedir36,/data/www/breakingaway/breakingawaygames/
+gamedir37,/data/www/xiangqi/xiangqigames/
+gamedir38,/data/www/container/containergames/
+gamedir39,/data/www/arimaa/arimaagames/
+gamedir40,/data/www/crossfire/crossfiregames/
+gamedir41,/data/www/entrapment/entrapmentgames/
+gamedir42,/data/www/lehavre/lehavregames/
+gamedir43,/data/www/gounki/gounkigames/
+gamedir44,/data/www/quinamid/quinamidgames/
+gamedir45,/data/www/twixt/twixtgames/
+gamedir46,/data/www/yspahan/yspahangames/
+gamedir47,/data/www/volo/vologames/
+gamedir48,/data/www/cookie/cookiegames/

--- a/server/cserver/DOCKER.md
+++ b/server/cserver/DOCKER.md
@@ -1,0 +1,80 @@
+# Docker container for BoardSpaceServer
+
+Containerizes this directory's C game server (`BoardSpaceServer`, built
+from `migs.c` and friends via the existing `makefile`).
+
+## Validated
+
+The exact source in this directory (`migs.c`, `migs-lib.c`, `savegame.c`,
+`websocket.c`) was compiled as-is in a Debian/gcc + OpenSSL 3.0 environment
+while developing this Dockerfile. It builds clean with only expected
+deprecation warnings (`ftime`, `TLSv1_2_server_method`, `SHA1_Init`/
+`Update`/`Final` -- OpenSSL 3.0/glibc noting older APIs still work, not new
+problems). Runtime library dependencies are exactly `libssl.so.3`,
+`libcrypto.so.3`, `libc.so.6`. The binary was also run directly and
+correctly printed its usage message.
+
+## Build
+
+From this directory:
+
+```
+docker build -t boardspace-cserver .
+```
+
+## Run
+
+```
+docker run -d --name cserver \
+  -p 2255:2255 \
+  -v boardspace-logs:/data/logs \
+  -v boardspace-games:/data/games \
+  -v boardspace-status:/data/status \
+  -v boardspace-www:/data/www \
+  -v $(pwd)/BoardSpaceServer.docker.conf:/data/conf/BoardSpaceServer.conf:ro \
+  boardspace-cserver
+```
+
+## Config file
+
+`BoardSpaceServer.docker.conf` is the shipped `BoardSpaceServer.conf` with
+paths remapped for containers:
+
+| original | container |
+|---|---|
+| `/home/boardspa/logs/` | `/data/logs/` |
+| `/home/boardspa/public_html/admin/` | `/data/status/` |
+| `/home/boardspa/bin/Games/` | `/data/games/` |
+| `/home/boardspa/www/<game>/<game>games/` | `/data/www/<game>/<game>games/` |
+
+The `gamedirN` entries (49 of them) point into what was the Apache web
+root's per-game subdirectories -- this is where the C server reads/writes
+saved game records that the PHP/CGI game-review pages also read directly.
+**The eventual Apache/PHP container needs to mount the same `/data/www`
+volume** (read-write if it also writes there, read-only if it's purely a
+viewer) so both containers see the same game files.
+
+This conf uses the "static" (baked-in) `gametype`/`gamedir` list, which is
+the usual approach for development. In production, `cgi-bin/tlib/
+serverconf.pl` regenerates that section of the conf from the `variation`
+table in the database (and creates any missing game directories) before a
+restart -- that's a separate, DB-driven step outside this container, not
+something this Dockerfile replicates.
+
+## Known limitation: strict-mode trust (not fixed here)
+
+`migs.c`'s `client_socket_init()` binds its listen socket to `INADDR_ANY`
+regardless of the `bindip` config value -- there's even a comment in the
+source noting an older version bound to the specific configured IP and
+that was deliberately changed. `bindip` is used *only* as the "trusted IP"
+value for strict-mode login checking: a connection is trusted if its
+source IP matches `bindip` or the hardcoded `127.0.0.1` fallback (`migs.c`
+~line 5214 and ~5536).
+
+That assumption held when Apache and the game server shared a host or at
+least a loopback interface. It breaks once they're separate containers on
+a Docker network, since neither value will match the real container-to-
+container source IP. This conf sets `strict,0` for now with a comment
+explaining why -- this is exactly the gap the planned HMAC-based
+replacement (shared secret between the C server and Apache/CGI) is meant
+to close. Re-enable `strict,1` only once that's implemented.

--- a/server/cserver/Dockerfile
+++ b/server/cserver/Dockerfile
@@ -1,0 +1,62 @@
+# Boardspace game server (cserver / BoardSpaceServer / migs.c)
+#
+# Lives in server/cserver, builds from this directory (build context = ".").
+# See DOCKER.md in this same directory for full build/run notes, the
+# known strict-mode/IP-trust limitation, and the /data/www volume-sharing
+# note relevant to the future Apache/PHP container.
+
+########################################
+# Stage 1: build
+########################################
+FROM debian:bookworm-slim AS builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Only the files the makefile's BoardSpaceServer target actually needs.
+COPY migs.c migs-lib.c migs-lib.h savegame.c websocket.c websocket.h \
+     migs-declarations.h threadmacros.h makefile ./
+
+RUN make BoardSpaceServer
+
+########################################
+# Stage 2: runtime
+########################################
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libssl3 \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --create-home --home-dir /home/boardspace --shell /usr/sbin/nologin boardspace
+
+WORKDIR /home/boardspace
+
+COPY --from=builder /build/BoardSpaceServer /usr/local/bin/BoardSpaceServer
+
+# Persistent/mounted state:
+#   /data/conf   - the server's .conf file (bind-mount your own)
+#   /data/logs   - Server.log, Chat.log, Security.log
+#   /data/games  - gamecachedir: cached game files
+#   /data/status - Server_Status.html (statusfile) -- if Apache's admin
+#                  page needs to read this, share this volume with that
+#                  container (read-only there).
+RUN mkdir -p /data/conf /data/logs /data/games /data/status \
+    && chown -R boardspace:boardspace /data /home/boardspace
+
+VOLUME ["/data/logs", "/data/games", "/data/status"]
+
+USER boardspace
+
+# Game port. Adjust/expose the websocket port too if websocketPortNum
+# (the "websocket" conf key) is set > 0 in your conf file.
+EXPOSE 2255
+
+ENTRYPOINT ["/usr/local/bin/BoardSpaceServer"]
+CMD ["/data/conf/BoardSpaceServer.conf"]


### PR DESCRIPTION
Two-stage Dockerfile (build-essential+libssl-dev builder, minimal libssl3 runtime, non-root user). Build validated by actually compiling migs.c/migs-lib.c/savegame.c/websocket.c as-is against Debian bookworm gcc + OpenSSL 3.0 -- clean build, only expected deprecation warnings, runtime deps just libssl.so.3/libcrypto.so.3/libc.so.6.

Includes a container-adapted conf (BoardSpaceServer.docker.conf, paths remapped under /data/*) and DOCKER.md covering build/run instructions plus two things worth reviewing:

- gamedirN entries point into the old Apache web root's per-game subdirectories; the eventual Apache/PHP container will need to share the same /data/www volume.
- strict-mode login trust (migs.c client_real_ip==server_ip check) only worked when Apache and the game server shared a host/loopback; it's set to strict,0 here until the planned HMAC-based replacement lands. See DOCKER.md for the exact code path (client_socket_init binds INADDR_ANY regardless of bindip; bindip is only used for this trust comparison, not the socket bind).